### PR TITLE
Add `--pw-debug` command-line option

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ The plugin adds several command-line arguments for flexibility:
 | `--pw-video`           | Video recording (`always`, `on-failure`, `on-reschedule`, `never`)      | `never`               |
 | `--pw-trace`           | Trace recording (`always`, `on-failure`, `on-reschedule`, `never`)      | `never`               |
 | `--pw-device`          | Emulate a specific device                                               | `None`                |
+| `--pw-debug`           | Enable Playwright debug mode by setting PWDEBUG=1                       | `False`               |
 
 ### Example Usage
 

--- a/vedro_pw/_pw_plugin.py
+++ b/vedro_pw/_pw_plugin.py
@@ -1,6 +1,6 @@
+import os
 from pathlib import Path
 from typing import Dict, Type, Union
-import os
 
 from vedro import FileArtifact, create_tmp_dir, create_tmp_file
 from vedro.core import Dispatcher, Plugin, PluginConfig

--- a/vedro_pw/_pw_plugin.py
+++ b/vedro_pw/_pw_plugin.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from typing import Dict, Type, Union
+import os
 
 from vedro import FileArtifact, create_tmp_dir, create_tmp_file
 from vedro.core import Dispatcher, Plugin, PluginConfig
@@ -95,6 +96,9 @@ class PlaywrightPlugin(Plugin):
         group.add_argument("--pw-device", action="store",
                            help="Emulate a specific device (e.g., iPhone 15 Pro or Pixel 7)")
 
+        group.add_argument("--pw-debug", action="store_true", default=False,
+                           help="Enable Playwright debug mode by setting PWDEBUG=1")
+
     def on_arg_parsed(self, event: ArgParsedEvent) -> None:
         self._runtime_config.set_browser(event.args.pw_browser)
         self._runtime_config.set_headed(event.args.pw_headed)
@@ -107,6 +111,9 @@ class PlaywrightPlugin(Plugin):
         self._capture_screenshots = event.args.pw_screenshots
         self._capture_video = event.args.pw_video
         self._capture_trace = event.args.pw_trace
+
+        if event.args.pw_debug:
+            os.environ["PWDEBUG"] = "1"
 
         if self._timeout is not None:
             self._runtime_config.set_timeout(self._timeout)


### PR DESCRIPTION
Fixes #1

Add `--pw-debug` command-line option to enable Playwright debug mode.

* Modify `vedro_pw/_pw_plugin.py` to add `--pw-debug` option in `on_arg_parse` method and set `os.environ["PWDEBUG"] = "1"` in `on_arg_parsed` method if the option is specified.
* Update `README.md` to include documentation for the new `--pw-debug` option.

