### PR TITLE
Add Playwright support for E2E testing infrastructure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,6 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        fail-fast: true
 
     steps:
     - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
 
     container:
       image: mcr.microsoft.com/playwright/python:v1.54.0-noble
-      options: --user 1001
+      options: --user root
 
     strategy:
       matrix:
@@ -36,8 +36,8 @@ jobs:
 
     - name: Install make
       run: |
-        sudo apt-get update
-        sudo apt-get install -y make
+        apt-get update
+        apt-get install -y make
 
     - name: Install dependencies
       run: make install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: make install
+    - name: Install Playwright Browsers
+      run: python -m playwright install --with-deps
     - name: Lint
       run: make lint
     - name: Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,11 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+
+    container:
+      image: mcr.microsoft.com/playwright/python:v1.54.0-noble
+      options: --user 1001
+
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
@@ -23,18 +28,21 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: make install
-    - name: Install Playwright Browsers
-      run: python -m playwright install --with-deps
+
     - name: Lint
       run: make lint
+
     - name: Test
       run: make coverage
+
     - name: Upload coverage
       uses: codecov/codecov-action@v4
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        fail-fast: true
 
     steps:
     - name: Checkout
@@ -33,6 +34,11 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+
+    - name: Install make
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y make
 
     - name: Install dependencies
       run: make install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: mcr.microsoft.com/playwright/python:v1.54.0-noble
+      image: mcr.microsoft.com/playwright/python:v1.55.0-noble
       options: --user root
 
     strategy:

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,13 @@ PROJECT_NAME=vedro_pw
 
 .PHONY: install
 install:
-	pip3 install --quiet --upgrade pip
-	pip3 install --quiet -r requirements.txt -r requirements-dev.txt
+	python3 -m pip install --quiet --upgrade pip
+	python3 -m pip install --quiet -r requirements.txt -r requirements-dev.txt
 
 .PHONY: build
 build:
-	pip3 install --quiet --upgrade pip
-	pip3 install --quiet --upgrade setuptools wheel twine
+	python3 -m pip install --quiet --upgrade pip
+	python3 -m pip install --quiet --upgrade setuptools wheel twine
 	python3 setup.py sdist bdist_wheel
 
 .PHONY: publish

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To install manually, follow these steps:
 1. Install the package using pip:
 
 ```shell
-$ pip3 install vedro-pw
+$ pip install vedro-pw
 ```
 
 2. Next, activate the plugin in your `vedro.cfg.py` configuration file:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ flake8==7.1.1
 isort==5.13.2
 mypy==1.13.0
 typing_extensions==4.12.2
+vedro_jj==0.2.0

--- a/tests/create_browser_context.py
+++ b/tests/create_browser_context.py
@@ -1,0 +1,13 @@
+from playwright.async_api import BrowserContext
+from vedro import scenario, then, when
+
+from vedro_pw import created_browser_context
+
+
+@scenario("create browser context")
+async def _():
+    with when:
+        context = await created_browser_context()
+
+    with then:
+        assert isinstance(context, BrowserContext)

--- a/tests/launch_browser.py
+++ b/tests/launch_browser.py
@@ -1,0 +1,19 @@
+from playwright.async_api import Browser
+from vedro import params, scenario, then, when
+
+from vedro_pw import launched_browser as launched_local_by_default
+from vedro_pw import launched_local_browser
+from vedro_pw._configurable_browser import ConfigurableBrowser
+
+
+@scenario("launch browser", [
+    params(launched_local_by_default),
+    params(launched_local_browser),
+])
+async def _(launched_browser):
+    with when:
+        browser = await launched_browser()
+
+    with then:
+        assert isinstance(browser, Browser)
+        assert isinstance(browser, ConfigurableBrowser)

--- a/tests/open_browser_page.py
+++ b/tests/open_browser_page.py
@@ -1,0 +1,47 @@
+import jj
+from jj.mock import mocked, Mocked
+from vedro import scenario, when, then, given
+
+from vedro_pw import opened_browser_page, expect
+
+
+@scenario("open blank page")
+async def _():
+    with when:
+        page = await opened_browser_page()
+
+    with then:
+        assert await expect(page).to_have_url("about:blank")
+
+
+def mocked_response(title: str) -> Mocked:
+    return mocked(
+        matcher=jj.match("*"),
+        response=jj.Response(
+            body=f"""
+                <html>
+                    <title>{title}</title>
+                    <body>
+                        <h1>Hello, World!</h1>
+                    </body>
+                </html>
+            """,
+            headers={"content-type": "text/html"}
+        )
+    )
+
+
+@scenario("open real page")
+async def _():
+    with given:
+        page = await opened_browser_page()
+
+        title = "<title>"
+
+    async with when, mocked_response(title) as mock:
+        await page.goto("http://localhost:8080")
+        await mock.wait_for_requests(1)
+
+    with then:
+        assert await expect(page).to_have_url("http://localhost:8080/")
+        assert await expect(page).to_have_title(title)

--- a/tests/open_browser_page.py
+++ b/tests/open_browser_page.py
@@ -1,8 +1,8 @@
 import jj
-from jj.mock import mocked, Mocked
-from vedro import scenario, when, then, given
+from jj.mock import Mocked, mocked
+from vedro import given, scenario, then, when
 
-from vedro_pw import opened_browser_page, expect
+from vedro_pw import expect, opened_browser_page
 
 
 @scenario("open blank page")

--- a/tests/open_real_page.py
+++ b/tests/open_real_page.py
@@ -1,0 +1,47 @@
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
+
+import jj
+from jj.mock import Mocked, mocked
+from vedro import given, scenario, then, when
+
+from vedro_pw import expect, opened_browser_page
+
+
+@asynccontextmanager
+async def mocked_response(title: str, *, wait_for_requests: int = 1) -> AsyncIterator[Mocked]:
+    matcher = jj.match("*")
+    response = jj.Response(
+        body=f"""
+            <html>
+                <title>{title}</title>
+                <body>
+                    <h1>Hello, World!</h1>
+                </body>
+            </html>
+        """,
+        headers={"content-type": "text/html"}
+    )
+
+    async with mocked(matcher, response) as mock:
+        mock: Mocked
+        yield mock
+        await mock.wait_for_requests(wait_for_requests)
+
+
+@scenario("open real page")
+async def _():
+    with given:
+        page = await opened_browser_page()
+
+        url = "http://localhost:8080/"
+        title = "<title>"
+
+    async with when, mocked_response(title) as mock:
+        await page.goto(url)
+
+    with then:
+        assert await expect(page).to_have_url(url)
+        assert await expect(page).to_have_title(title)
+
+        assert len(mock.history) == 1

--- a/vedro.cfg.py
+++ b/vedro.cfg.py
@@ -1,0 +1,16 @@
+import vedro
+
+import vedro_jj
+import vedro_pw
+
+
+class Config(vedro.Config):
+
+    class Plugins(vedro.Config.Plugins):
+        class Playwright(vedro_pw.Playwright):
+            enabled = True
+
+        class VedroJJ(vedro_jj.VedroJJ):
+            enabled = True
+            host = "localhost"
+            port = 8080


### PR DESCRIPTION
 This PR sets up the foundation for end-to-end testing using Playwright:

  - CI/CD: Updated GitHub Actions workflow to use Playwright container image for consistent browser testing
  environment
  - Dependencies: Added vedro_jj for browser automation testing
  - Configuration: Added Vedro config with Playwright and VedroJJ plugins for browser-based testing
  - Build: Added make installation step to ensure build tools are available in container